### PR TITLE
Fixed a typo

### DIFF
--- a/iptables-persistent
+++ b/iptables-persistent
@@ -72,7 +72,7 @@ save_rules()
     log_action_cont_msg " skipping IPset - no sets defined or not loaded"
   elif [ -x /usr/sbin/ipset ] || [ -x /sbin/ipset ]; then
     log_action_cont_msg " IPset"
-    ipset save | grep -iv "f2b"> /etc/iptables/rules.ipsets
+    ipset save | grep -iv "f2b"> /etc/iptables/rules.ipset
     if [ $? -ne 0 ]; then
       rc=1
     fi


### PR DESCRIPTION
IPset rules were saved to `rules.ipsets`, but loaded from `rules.ipset`, causing no rules to load.
I guess this fixes my #3 issue as well and not all strings were changed in #1 causing this bug.